### PR TITLE
[SL Beta 2] Bump module version for Beta 2 release

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "snowflake.driver"
-version = "0.1.0"
+version = "1.0.1"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["snowflake","cloud","data warehouse"]


### PR DESCRIPTION
## Purpose
> Bump module version for Beta 2 release

## Goals
> Bump module version for Beta 2 release

## Approach
> 
- Remove JDBC driver jar folder
- Bump module version to 1.0.1

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
> 
JDK 11
Ballerina Beta 2
Ubuntu 20.04