### PR TITLE
[SL Alpha 5] Bump module version for Alpha 5 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
             # Build the ballerina project
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action@slbeta2
+              uses: ballerina-platform/ballerina-action@slalpha5
               with:
                   args:
                       build -c

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
             
             # Build the ballerina project
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action@slbeta2
+              uses: ballerina-platform/ballerina-action@slalpha5
               with:
                   args:
                       build -c

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
             # Build the ballerina project
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action@slbeta2
+              uses: ballerina-platform/ballerina-action@slalpha5
               with:
                   args:
                       build -c
@@ -35,7 +35,7 @@ jobs:
 
             # Push the module to the Ballerina central
             - name: Ballerina Push
-              uses: ballerina-platform/ballerina-action@slbeta2
+              uses: ballerina-platform/ballerina-action@slalpha5
               with:
                   args:
                       push

--- a/Package.md
+++ b/Package.md
@@ -7,7 +7,7 @@ This package bundles the latest Snowflake JDBC Driver.
 ### Compatibility
 |                                   | Version                         |
 |-----------------------------------|---------------------------------|
-| Ballerina Language                | Ballerina Swan Lake Beta2       | 
+| Ballerina Language                | Ballerina Swan Lake Alpha5      | 
 | Snowflake JDBC Driver             | 3.13.6                          |
 
 ## Report issues

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information, go to the module(s).
 
     > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-2. Download and install [Ballerina Swan Lake Beta2](https://ballerina.io/). 
+2. Download and install [Ballerina Swan Lake Alpha5](https://ballerina.io/). 
 
 ### Building the source
 


### PR DESCRIPTION
## Purpose
> Bump module version for Alpha 5 release

## Goals
> Bump module version for Alpha 5 release

## Approach
> 
- Remove JDBC driver jar folder
- Bump module version to 0.1.0

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes


## Test environment
> 
JDK 11
Ballerina for Alpha 5
Ubuntu 20.04