### PR TITLE
[SL Alpha 5] Fix driver not detected issue

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "snowflake.driver"
-version = "0.1.0"
+version = "0.1.1"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["snowflake","cloud","data warehouse"]

--- a/snowflake.bal
+++ b/snowflake.bal
@@ -16,3 +16,5 @@
 
 // This file is here for the purpose of building the connector driver module. 
 // We need add at least one .bal file to build the module.
+
+import ballerina/jballerina.java as _;


### PR DESCRIPTION
## Purpose
> Driver is not detected due to an issue in Ballerina SL Alpha 5. This PR fix this issue. 

## Goals
> Fix driver not detected issue

## Approach
> 
Add `import ballerina/jballerina.java as _;` in .bal file
Bump module version to 0.1.1

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> 
JDK 11
Ballerina for Alpha 5
Ubuntu 20.04