### PR TITLE
Migrate to slbeta6

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,8 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "snowflake.driver"
-version = "2.0.0"
+version = "2.1.0"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Business Intelligence/Data Warehouse", "Cost/Paid"]
@@ -14,4 +15,4 @@ observabilityIncluded = true
 [[platform.java11.dependency]]
 groupId = "net.snowflake"
 artifactId = "snowflake-jdbc"
-version = "3.13.6"
+version = "3.13.11"

--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -37,7 +37,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "snowflake.driver"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}

--- a/Module.md
+++ b/Module.md
@@ -1,5 +1,5 @@
 ## Overview
-This is a Ballerina library for [Snowflake JDBC Driver v3.13.6](https://docs.snowflake.com/en/user-guide/jdbc.html). 
+This is a Ballerina library for [Snowflake JDBC Driver v3.13.11](https://docs.snowflake.com/en/user-guide/jdbc.html). 
 The Snowflake JDBC driver is a JDBC type 4 driver that supports the core JDBC functionality in version 1.0 of the JDBC API.
 You can create and manage all Snowflake objects, including virtual warehouses, databases, and all database objects. 
 It also provides the capability to query Snowflake data. You can find reference information for all the Snowflake SQL commands (DDL, DML, and query syntax) [here](https://docs.snowflake.com/en/sql-reference-commands.html). You can find reference information for the system-defined SQL functions [here](https://docs.snowflake.com/en/sql-reference-functions.html).
@@ -51,7 +51,7 @@ jdbc:Client baseClient = check new (jdbcUrl, user, password, options = options);
     ```ballerina
     public function main() {
         sql:ParameterizedQuery sqlQuery = `SELECT CURRENT_CLIENT()`;
-        stream <record {}, sql:Error> resultStream = baseClient->query(sqlQuery);
+        stream <record {}, sql:Error?> resultStream = baseClient->query(sqlQuery);
         record {|record {} value;|}|error? result = resultStream.next();
         if result is record {|record {} value;|} {
             io:println("Current driver version: ", result.value);
@@ -66,7 +66,7 @@ jdbc:Client baseClient = check new (jdbcUrl, user, password, options = options);
     ```ballerina
     public function main() {
         sql:ParameterizedQuery sqlQuery = `SELECT CURRENT_WAREHOUSE(), CURRENT_DATABASE(), CURRENT_SCHEMA()`;
-        stream <record {}, sql:Error> resultStream = baseClient->query(sqlQuery);
+        stream <record {}, sql:Error?> resultStream = baseClient->query(sqlQuery);
         record {|record {} value;|}|error? result = resultStream.next();
         if result is record {|record {} value;|} {
             io:println("Current details: ", result.value);
@@ -81,7 +81,7 @@ jdbc:Client baseClient = check new (jdbcUrl, user, password, options = options);
     ```ballerina
     public function main() {
         sql:ParameterizedQuery sqlQuery = `SELECT * FROM DEMO`;
-        stream <record {}, sql:Error> resultStream = baseClient->query(sqlQuery);
+        stream <record {}, sql:Error?> resultStream = baseClient->query(sqlQuery);
 
         error? e = resultStream.forEach(isolated function(record {} result) {
             io:println("Current query details: ", result);

--- a/Package.md
+++ b/Package.md
@@ -7,8 +7,8 @@ This package bundles the latest Snowflake JDBC Driver.
 ### Compatibility
 |                                   | Version                         |
 |-----------------------------------|---------------------------------|
-| Ballerina Language                | Ballerina Swan Lake Beta3       | 
-| Snowflake JDBC Driver             | 3.13.6                          |
+| Ballerina Language                | Ballerina Swan Lake Beta6       | 
+| Snowflake JDBC Driver             | 3.13.11                         |
 
 ## Report issues
 To report bugs, request new features, start new discussions, view project boards, etc., go to the [Ballerina Extended Library repository](https://github.com/ballerina-platform/ballerina-extended-library)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information, go to the module(s).
 
     > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-2. Download and install [Ballerina Swan Lake Beta3](https://ballerina.io/). 
+2. Download and install [Ballerina Swan Lake](https://ballerina.io/). 
 
 ### Building the source
 


### PR DESCRIPTION
# Description

Migrate the snowflake driver repository with latest JDBC jar updates for SLBeta6 release. 

- Bump version to `2.1.0`
- Update Snowflake JDBC jar to latest version `3.13.11` in Ballerina.toml
- Add `distribution = "slbeta6"` in Ballerina.toml
- Regenerate Dependencies.toml with `SLBeta6`
- Update Snowflake JDBC jar version to `3.13.11` in Module.md 
- Update sample codes in Module.md 
- Update Ballerina version to `SLBeta6` in Package.md 

Resolves https://github.com/ballerina-platform/ballerina-extended-library/issues/206

One line release note: 
- Update Snowflake JDBC jar to latest version `3.13.11`

**Test Configuration**:
* Ballerina Version: SLBeta6
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
