### PR TITLE
Bump module version to 2.3.0

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.0.0"
 org = "ballerinax"
 name = "snowflake.driver"
-version = "2.2.0"
+version = "2.3.0"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Business Intelligence/Data Warehouse", "Cost/Paid"]

--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -37,7 +37,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "snowflake.driver"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerinai", name = "observe"}


### PR DESCRIPTION
# Description

Bump module version for 2.3.0 release

One line release note: 
- Remove client class

**Test Configuration**:
* Ballerina Version: 2201.0.0
* Operating System: Ubuntu 20.04
* Java SDK: 11
